### PR TITLE
refactor: migrate to official status

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 ## Manual Testing Instructions
 
 ```bash
-ddev add-on get https://github.com/ddev/ddev-cypress/tarball/<branch>
+ddev add-on get https://github.com/ddev/ddev-cypress/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
 ddev restart
 ```
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 ## Manual Testing Instructions
 
 ```bash
-ddev add-on get https://github.com/tyler36/ddev-cypress/tarball/<branch>
+ddev add-on get https://github.com/ddev/ddev-cypress/tarball/<branch>
 ddev restart
 ```
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,12 @@
 name: tests
 on:
   pull_request:
+    paths-ignore:
+      - "**.md"
   push:
     branches: [ main ]
+    paths-ignore:
+      - "**.md"
 
   schedule:
   - cron: '01 07 * * *'

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ The main benefit is integration of Chrome and Firefox browsers out of the box, p
 This addon:
 
 - provides Cypress without the need to install <a href="https://nodejs.org">Node.js</a>
-- provides Firefox and Chromium out of the box, preconfigured for Cypress
+- provides Firefox and Chromium out of the box, pre-configured for Cypress
 - configures your project's HTTPS site a base URL
 - provides helper commands for running Cypress GUI or in headless mode
 
-Installing Cypress with favorite package manager works great locally. However, maintaining a consistent node and browser environments across teams, operating systrems, CI/CS development pipelines and cloud development spaces can become a challenge.
+Installing Cypress with favorite package manager works great locally. However, maintaining a consistent node and browser environments across teams, operating systems, CI/CS development pipelines and cloud development spaces can become a challenge.
 
 <a href="https://www.drupal.org/docs/develop/automated-testing/browser-testing-using-cypress">Browser testing using Cypress</a> sets up Cypress for Drupal manually. For Linux users this could be easier, since X11 and Firefox are usually already present.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
-[![tests](https://github.com/tyler36/ddev-cypress/actions/workflows/tests.yml/badge.svg)](https://github.com/tyler36/ddev-cypress/actions/workflows/tests.yml)
-[![last commit](https://img.shields.io/github/last-commit/tyler36/ddev-cypress)](https://github.com/tyler36/ddev-cypress/commits)
-[![release](https://img.shields.io/github/v/release/ddev/ddev-cypress)](https://github.com/tyler36/ddev-cypress/releases/latest)
+[![tests](https://github.com/ddev/ddev-cypress/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-cypress/actions/workflows/tests.yml)
+[![last commit](https://img.shields.io/github/last-commit/ddev/ddev-cypress)](https://github.com/ddev/ddev-cypress/commits)
+[![release](https://img.shields.io/github/v/release/ddev/ddev-cypress)](https://github.com/ddev/ddev-cypress/releases/latest)
 
 # DDEV-cypress <!-- omit in toc -->
 
@@ -55,7 +55,7 @@ Installing Cypress with favorite package manager works great locally. However, m
 - Install service
 
   ```shell
-  ddev add-on get tyler36/ddev-cypress
+  ddev add-on get ddev/ddev-cypress
   ```
 
   Then restart the project
@@ -65,7 +65,7 @@ Installing Cypress with favorite package manager works great locally. However, m
   ```
 
 > [!NOTE]
-> If you change `additional_hostnames` or `additional_fqdns`, you have to re-run `ddev add-on get tyler36/ddev-cypress`
+> If you change `additional_hostnames` or `additional_fqdns`, you have to re-run `ddev add-on get ddev/ddev-cypress`
 
 - Run cypress via `ddev cypress-open` or `ddev cypress-run` (headless).
 

--- a/commands/cypress/cypress-open
+++ b/commands/cypress/cypress-open
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #ddev-generated
 
 ## Description: Open an interactive Cypress window

--- a/commands/cypress/cypress-run
+++ b/commands/cypress/cypress-run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #ddev-generated
 ## Description: Use Cypress in "runner" mode.
 ##

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -37,8 +37,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev add-on get tyler36/ddev-cypress with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev add-on get tyler36/ddev-cypress
+  echo "# ddev add-on get ddev/ddev-cypress with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ddev/ddev-cypress
   ddev restart >/dev/null
   health_checks
 }


### PR DESCRIPTION
## The Issue

This addon was transfered to DDEV but needs references updated.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR updates the badges and install instructions to point to DDEV.
The tests were also updated.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-cypress/tarball/20250922-promote-to-official
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
